### PR TITLE
feat: manually create tables with schema and data rows

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -778,6 +778,143 @@
   resize: vertical;
 }
 
+/* ── Create Table modal ─────────────────────────────── */
+.create-table__label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+  margin-bottom: 0.75rem;
+}
+
+.create-table__name-input {
+  padding: 0.4rem 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 0.9rem;
+}
+
+.create-table__columns-fieldset,
+.create-table__rows-fieldset {
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.create-table__columns-fieldset legend,
+.create-table__rows-fieldset legend {
+  font-weight: 600;
+  font-size: 0.85rem;
+  padding: 0 0.25rem;
+}
+
+.create-table__columns-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.create-table__column-row {
+  display: flex;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.create-table__column-row input {
+  flex: 1;
+  padding: 0.3rem 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.85rem;
+}
+
+.create-table__remove-col {
+  background: none;
+  border: none;
+  color: #c00;
+  cursor: pointer;
+  font-size: 1.1rem;
+  padding: 0 0.3rem;
+  line-height: 1;
+}
+.create-table__remove-col:disabled {
+  visibility: hidden;
+}
+
+.create-table__add-col,
+.create-table__add-row {
+  margin-top: 0.5rem;
+  background: none;
+  border: 1px dashed #aaa;
+  border-radius: 4px;
+  padding: 0.3rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: #555;
+}
+.create-table__add-col:hover,
+.create-table__add-row:hover {
+  border-color: #0078d4;
+  color: #0078d4;
+}
+
+.create-table__grid-wrapper {
+  max-height: 260px;
+  overflow: auto;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+}
+
+.create-table__grid {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+}
+
+.create-table__grid th {
+  background: #f5f5f5;
+  padding: 0.3rem 0.5rem;
+  text-align: left;
+  font-weight: 600;
+  position: sticky;
+  top: 0;
+  border-bottom: 1px solid #ddd;
+}
+
+.create-table__grid td {
+  padding: 0.15rem 0.25rem;
+  border-bottom: 1px solid #eee;
+}
+
+.create-table__grid td input {
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  padding: 0.2rem 0.35rem;
+  font-size: 0.82rem;
+}
+.create-table__grid td input:focus {
+  border-color: #0078d4;
+  outline: none;
+}
+
+.create-table__grid-action {
+  width: 28px;
+  text-align: center;
+}
+.create-table__grid-action button {
+  background: none;
+  border: none;
+  color: #c00;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
 .modal__footer {
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
## Summary

Adds the ability to manually create tables directly in the app, without needing to import a file.

### How to use
1. **Load Data → Create Table**
2. Enter a table name
3. Add columns (press Enter to quickly add more)
4. Optionally add data rows via the inline grid
5. Click **Create**

The table appears on the canvas and works exactly like a file-imported table — you can create relationships, rename columns, set as root, etc.

### Changes
- **src/App.tsx** — Added \createTableOpen\, \createTableColumns\, \createTableRows\ state; \handleCreateTable\ callback; modal UI with column editor and data grid
- **src/App.css** — Styles for create-table modal: column list, add/remove buttons, scrollable data grid with sticky headers